### PR TITLE
Typos in specifying paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SU_OUTDIR=../out/supervised/
 BATCH=64
 PATIENCE=5
 
-$ python python supervised_alignment.py --batch $BATCH --out $SU_OUTDIR --data $DATA --sure_and_possible --model bert-base-uncased --ot_type $OT --weight_type $WT --dist_type $DT --seed $SEED --patience $PATIENCE --unsupervised_dir $UN_OUTDIR
+$ python python supervised_alignment.py --batch $BATCH --out $SU_OUTDIR --data $DATA --sure_and_possible --model bert-base-uncased --ot_type $OT --weight_type $WT --dist_type $DT --seed $SEED --patience $PATIENCE --unsupervised_dir $SU_OUTDIR
 ```
 
 # Citation

--- a/src/preprocess/edinburgh.py
+++ b/src/preprocess/edinburgh.py
@@ -70,7 +70,7 @@ def select_from_list(input_list, indices):
 if __name__ == '__main__':
     corpus_path = '../../data/edinburgh/test.json'
     sure_and_possible = False
-    out_path = '../data/edinburgh/sure_'
+    out_path = '../../data/edinburgh/sure_'
 
     # Consolidate annotations
     sents1, sents2, alignments = load_Edinburgh_corpus(corpus_path, sure_and_possible)

--- a/src/preprocess/msr_rte.py
+++ b/src/preprocess/msr_rte.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     # out_path = '../data/RTE-2006-Aligned/sure-and-possible_'
     corpus_dir = '../../data/RTE-2006-Aligned/Test/'
     sure_and_possible = False
-    out_path = '../data/RTE-2006-Aligned/sure_'
+    out_path = '../../data/RTE-2006-Aligned/sure_'
 
     all_annotators = []
     for file_path in glob.glob(corpus_dir + '*.align.txt'):


### PR DESCRIPTION
There is a mismatch between the data path where the preprocessed files are being saved & the data path given for loading in the load_WA_corpus function [L174](https://github.com/yukiar/OTAlign/blob/11512089c0152586080288f36d01f2c3f2c9d0a9/src/util.py#L174).